### PR TITLE
fromstring() --> frombytes()

### DIFF
--- a/bamnostic/core.py
+++ b/bamnostic/core.py
@@ -319,7 +319,7 @@ class AlignedSegment(object):
         self._raw_qual = unpack('<{}s'.format(self.l_seq), self._range_popper(self.l_seq))
 
         self.query_qualities = array('B')
-        self.query_qualities.fromstring(self._raw_qual)
+        self.query_qualities.frombytes(self._raw_qual)
         """Phred Quality scores for each base of the alignment
         ***without*** an ASCII offset."""
 


### PR DESCRIPTION
[This build](https://travis-ci.org/dib-lab/sourmash/jobs/428784272) was failing because the following error was printed too many times and Travis killed the job:

```
 /home/travis/build/dib-lab/sourmash/.tox/py36/src/bamnostic/bamnostic/core.py:203: DeprecationWarning:fromstring() is deprecated. Use frombytes() instead.
```

Hopefully this passes and can be smoothly added!