### PR TITLE
Update quickstart.rst

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -26,7 +26,7 @@ within the package.
 
 .. code:: python
 
-    >>> bam = bs.AlignmentFile(bs.example_path, 'rb')
+    >>> bam = bs.AlignmentFile(bs.example_bam, 'rb')
 
 Get the header
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
A contradiction between the text above and the example code. I check in the package, it should be example_bam as in the text.
Have a nice day.