### PR TITLE
Fix parsing for sequences of length 1

### DIFF
--- a/bamnostic/core.py
+++ b/bamnostic/core.py
@@ -372,7 +372,7 @@ class AlignedSegment(object):
         """
         if self.seq != "*":
             self._raw_qual = unpack(
-                "<{}s".format(self.l_seq), self._range_popper(self.l_seq), is_sequence=True
+                "<{}s".format(self.l_seq), self._range_popper(self.l_seq)
             )
 
             self.query_qualities = array("B")

--- a/bamnostic/core.py
+++ b/bamnostic/core.py
@@ -349,7 +349,7 @@ class AlignedSegment(object):
             self.seq = "*"
         else:
             self._byte_seq = unpack(
-                "<{}B".format((self.l_seq + 1) // 2), byte_data, is_sequence=True
+                "<{}B".format((self.l_seq + 1) // 2), byte_data, is_array=True
             )
             self.seq = "".join(
                 [

--- a/bamnostic/core.py
+++ b/bamnostic/core.py
@@ -142,12 +142,12 @@ class AlignmentFile(bam.BamReader, bam.BamWriter):
         kwargs.pop('self')
 
         assert 'b' in mode.lower(), 'BAM files must be used in binary mode'
-        
+
         write_modes = ['w', 'a', 'x', 'r+']
 
         # Check if user wants to write a BAM file
         if any([wm in mode.lower() for wm in write_modes]):
-            write_args = ('filepath_or_object', 'mode', 'compresslevel', 
+            write_args = ('filepath_or_object', 'mode', 'compresslevel',
                         'ignore_overwrite', 'copy_header', 'header',
                         'reference_names', 'reference_lengths')
             wargs = {}
@@ -189,8 +189,8 @@ class AlignedSegment(object):
         bsize_buffer = self._io.read(4)
         try:
             block_size = unpack_int32(bsize_buffer)[0]
-        
-        # Check for EOF: If the cursor is at the end of file, read() will return 
+
+        # Check for EOF: If the cursor is at the end of file, read() will return
         # an empty byte string.
         except struct.error:
             if all([not bsize_buffer, not self._io._handle.read()]):
@@ -223,7 +223,7 @@ class AlignedSegment(object):
 
         # Iteratively pull out the tags for the given aligned segment
         self._tag_builder()
-        
+
         # Process the CIGAR: accounts for CIGAR strings > 65535 operations
         self._decode_cigar()
 
@@ -349,7 +349,7 @@ class AlignedSegment(object):
             self.seq = "*"
         else:
             self._byte_seq = unpack(
-                "<{}B".format((self.l_seq + 1) // 2), byte_data
+                "<{}B".format((self.l_seq + 1) // 2), byte_data, is_sequence=True
             )
             self.seq = "".join(
                 [
@@ -372,7 +372,7 @@ class AlignedSegment(object):
         """
         if self.seq != "*":
             self._raw_qual = unpack(
-                "<{}s".format(self.l_seq), self._range_popper(self.l_seq)
+                "<{}s".format(self.l_seq), self._range_popper(self.l_seq), is_sequence=True
             )
 
             self.query_qualities = array("B")

--- a/bamnostic/core.py
+++ b/bamnostic/core.py
@@ -129,27 +129,48 @@ class AlignmentFile(bam.BamReader, bam.BamWriter):
 
     """
 
-    def __init__(self, filepath_or_object, mode="rb", max_cache=128, index_filename=None,
-                 filename=None, check_header=False, check_sq=True, reference_filename=None,
-                 filepath_index=None, require_index=False, duplicate_filehandle=None,
-                 ignore_truncation=False, compresslevel = 6, ignore_overwrite = False,
-                copy_header = None, header = b'', reference_names = None, reference_lengths = None):
-        """Initialize the class.
-
-        """
+    def __init__(
+        self,
+        filepath_or_object,
+        mode="rb",
+        max_cache=128,
+        index_filename=None,
+        filename=None,
+        check_header=False,
+        check_sq=True,
+        reference_filename=None,
+        filepath_index=None,
+        require_index=False,
+        duplicate_filehandle=None,
+        ignore_truncation=False,
+        compresslevel=6,
+        ignore_overwrite=False,
+        copy_header=None,
+        header=b"",
+        reference_names=None,
+        reference_lengths=None,
+    ):
+        """Initialize the class."""
 
         kwargs = locals()
-        kwargs.pop('self')
+        kwargs.pop("self")
 
-        assert 'b' in mode.lower(), 'BAM files must be used in binary mode'
+        assert "b" in mode.lower(), "BAM files must be used in binary mode"
 
-        write_modes = ['w', 'a', 'x', 'r+']
+        write_modes = ["w", "a", "x", "r+"]
 
         # Check if user wants to write a BAM file
         if any([wm in mode.lower() for wm in write_modes]):
-            write_args = ('filepath_or_object', 'mode', 'compresslevel',
-                        'ignore_overwrite', 'copy_header', 'header',
-                        'reference_names', 'reference_lengths')
+            write_args = (
+                "filepath_or_object",
+                "mode",
+                "compresslevel",
+                "ignore_overwrite",
+                "copy_header",
+                "header",
+                "reference_names",
+                "reference_lengths",
+            )
             wargs = {}
             for key in write_args:
                 try:
@@ -159,10 +180,20 @@ class AlignmentFile(bam.BamReader, bam.BamWriter):
             bam.BamWriter.__init__(self, **wargs)
 
         else:
-            read_args = ('filepath_or_object', 'mode', 'max_cache', 'index_filename',
-                'filename', 'check_header', 'check_sq', 'reference_filename',
-                'filepath_index', 'require_index', 'duplicate_filehandle',
-                'ignore_truncation')
+            read_args = (
+                "filepath_or_object",
+                "mode",
+                "max_cache",
+                "index_filename",
+                "filename",
+                "check_header",
+                "check_sq",
+                "reference_filename",
+                "filepath_index",
+                "require_index",
+                "duplicate_filehandle",
+                "ignore_truncation",
+            )
             rargs = {}
             for key in read_args:
                 try:

--- a/bamnostic/utils.py
+++ b/bamnostic/utils.py
@@ -818,3 +818,5 @@ def cigar_alignment(seq=None, cigar=None, start_pos = 0, qualities=None, base_qu
             last_cigar_pos += n_ops
         else:
             raise ValueError('Invalid CIGAR string: {}'.format(op))
+
+            

--- a/bamnostic/utils.py
+++ b/bamnostic/utils.py
@@ -293,7 +293,7 @@ def parse_region(contig=None, start=None, stop=None, region=None,
 
     Examples:
         .. code-block:: python
-        
+
             # Keyword-based
             >>> parse_region(contig = 'chr1', start = 10, stop = 100)
             Roi(contig: chr1, start: 10, stop: 100)
@@ -358,7 +358,7 @@ def parse_region(contig=None, start=None, stop=None, region=None,
 
     return query
 
-def unpack(fmt, _io):
+def unpack(fmt, _io, is_sequence=False):
     """Utility function for unpacking binary data from file object or byte
     stream.
 
@@ -382,7 +382,7 @@ def unpack(fmt, _io):
     except:
         # if it is a file object
         out = struct.unpack(fmt, _io.read(size))
-    if len(out) > 1:
+    if len(out) > 1 or is_sequence:
         return out
     else:
         return out[0]
@@ -446,7 +446,7 @@ class LruDict(OrderedDict):
     def __init__(self, *args, **kwargs):
         """ Initialize the dictionary based on collections.OrderedDict. This
         is built of the basic `OrderedDict`. The major difference in instantiation
-        is the usage of the `max_cache` argument. This sets the dictionary size 
+        is the usage of the `max_cache` argument. This sets the dictionary size
         to be used.
 
         Args:
@@ -512,7 +512,7 @@ class LruDict(OrderedDict):
             link[0] = root
             link[1] = first
             first[0] = soft_link
-            root[1] = link 
+            root[1] = link
 
     def update(self, others):
         """ Same as a regular `dict.update`, however, since pypy's `dict.update`

--- a/bamnostic/utils.py
+++ b/bamnostic/utils.py
@@ -358,7 +358,7 @@ def parse_region(contig=None, start=None, stop=None, region=None,
 
     return query
 
-def unpack(fmt, _io, is_sequence=False):
+def unpack(fmt, _io, is_array=False):
     """Utility function for unpacking binary data from file object or byte
     stream.
 
@@ -382,7 +382,7 @@ def unpack(fmt, _io, is_sequence=False):
     except:
         # if it is a file object
         out = struct.unpack(fmt, _io.read(size))
-    if len(out) > 1 or is_sequence:
+    if len(out) > 1 or is_array:
         return out
     else:
         return out[0]


### PR DESCRIPTION
Hi bamnostic devs,

Awesome package, I love it!
I think I found a bug in the case of sequences of length 1. Very rare, but can be produced by nanopore basecalling algorithms.
I have a fix that works, not sure how good it integrates into the overall codebase. I'm using the package since today.

I think my atom made a couple of formatting changes, let me know if you want me to revert those.

Let me know what you think,
Cheers,

Pay