### PR TITLE
Fix for #41

### DIFF
--- a/bamnostic/core.py
+++ b/bamnostic/core.py
@@ -309,6 +309,7 @@ class AlignedSegment(object):
         ).decode()[:-1]
 
         self.tid = self.reference_id = self.refID
+        self.reference_name = "*"
         try:
             self.reference_name = self._io._header.refs[self.refID][0]
         except KeyError:

--- a/bamnostic/core.py
+++ b/bamnostic/core.py
@@ -299,9 +299,12 @@ class AlignedSegment(object):
 
         self.flag = self._flag_nc >> 16
         self._n_cigar_op = self._flag_nc & 0xFFFF
-        self.l_seq, self.next_refID, self.next_pos, self.tlen = _unpack_lseq_nrid_npos_tlen(
-            self._range_popper(16)
-        )
+        (
+            self.l_seq,
+            self.next_refID,
+            self.next_pos,
+            self.tlen,
+        ) = _unpack_lseq_nrid_npos_tlen(self._range_popper(16))
 
         self.read_name = unpack(
             "<{}s".format(self._l_read_name),


### PR DESCRIPTION
Proposed fix for #41, where AlignedSegment objects were being created without a self.reference_name attribute.
AlignedSegment now always has self.reference_name attribute, which is set as "*" if no reference name is found.