### PR TITLE
Fix empty tag caused AttributeError

### DIFF
--- a/bamnostic/utils.py
+++ b/bamnostic/utils.py
@@ -384,6 +384,12 @@ def unpack(fmt, _io, is_array=False):
     Returns:
         unpacked contents from _io based on fmt string
     """
+    # Unpack binary data safely. Returns None or empty tuple if _io is None
+    if _io is None:
+        if is_array:
+            return tuple()
+        return None
+
     size = struct.calcsize(fmt)
     try:
         # if it is byte object


### PR DESCRIPTION
I used the `bamnostic` version `1.1.10` to process some modified BAM.

When it encontered read with empty `MM` or `ML` tag, the `unpack` function raise AttributeError
```
bf90265e-77af-46ac-92f6-60e1a11af156    16      chr1    5002582 60      315M    *       0       0       TTGCCTCTTCTTCTGTTGTTTATAAATATTATATCAGTGAGAAAAGATGCAGCCCCAGGGAACAACAAAATGAGTTGGCATGGTAATAGAGCAGCCATTTTGGAAATCCAGTAGAGAAGCCAGAAGCCACTTGCTTGGGCAGTCAACATTGATGCCTGCAAGCTTCTGCCCTTTACAACTTGGAAGGCAAATATGAAAAACTCTGAGATTACAATAAAAATCTCATTGTAAATCATCACAGAGAACACTGACTGGAGGCAAAGATTTGACTTCCAGCTTCAAATGTGAGAGGCAGGATGGTGAATAGAAAAGGGA     6=@ACABCDEEGFFJJIMKKJJJGGGFGHFGGFDFFC?<-,---91BCFIFFFFFHEHHHHDDFGJJJKMKKIIIJHIHFFGGFGGGFHHHKQMMOJJJGGHGCBCCCFHGFFJHHISSNKSIJJFFED9999::DHIIKKHIJIIOSSRIIGGHOJJILKSNHIKIKMLFJJKIIKGIFINLPRFGGFDG<81..----9:>EIIILJIFFCC@BB@CBBGGGJJKIISMMSPSMRSIIHIILHJJFFJIJGJHJJKKJJIIJIIJLIIIIHHJJIIJIFFFJFGIIHJJIJKJIJJJJJLKNMSSMMDBCDCI qs:f:24.903du:f:0.8252      ns:i:4126       ts:i:466        mx:i:4  ch:i:2599       st:Z:2023-04-27T07:39:00.714+00:00      rn:i:176878     fn:Z:PAO89685_pass__2264ba8c_afee3a87_1523.pod5 sm:f:-791.842       sd:f:0.00795814 sv:Z:pa dx:i:0  RG:Z:afee3a87585a5c58b78955ac2f01d681f6359a75_dna_r10.4.1_e8.2_400bps_sup@v5.0.0        MN:i:315        MM:Z:C+h?;C+m?; ML:B:C  NM:i:1  ms:i:624   AS:i:624 nn:i:0  de:f:0.0031746  tp:A:P  cm:i:23 s1:i:271        s2:i:0  MD:Z:235C79     rl:i:0
```

The original error:
```
AttributeError: 'NoneType' object has no attribute 'read'
```

I simply added an `if` to check if the `_io` is `None` or not first.
